### PR TITLE
Add required build- and run-time dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=42.0.0",
+    "Cython",
+    "numpy"
+]
+
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42.0.0",
     "Cython",
-    "numpy"
+    "oldest-supported-numpy",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
    version = "1.0.0",
    url = "https://git.mpi-hd.mpg.de/ssailer/pyfcutils",
    long_description=read('README.md'),
-   ext_modules = cythonize(ext_modules, language_level=3)
+   ext_modules = cythonize(ext_modules, language_level=3),
+   install_requires=["numpy"]
 )


### PR DESCRIPTION
The package pip-installs now correctly without having to manually install dependencies.